### PR TITLE
add breadcrumbs in item-show

### DIFF
--- a/resources/views/item/show.blade.php
+++ b/resources/views/item/show.blade.php
@@ -1,6 +1,14 @@
 @extends('layouts.app')
 
 @section('content')
+  <nav aria-label="breadcrumb" role="navigation">
+    <ol class="breadcrumb pl-5">
+        <li class="breadcrumb-item"><a href="#">トップページ</a></li>
+        <li class="breadcrumb-item"><a href="#">{{$item->category->parent->name}}</a></li>
+        <li class="breadcrumb-item"><a href="#">{{$item->category->name}}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{$item->name}}</a></li>
+    </ol>
+  </nav>
   <div class="container">
     <div class="row justify-content-left">
       <div class="justify-content-start col-8 bg-light">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -77,7 +77,6 @@
                 </div>
             </div>
         </nav>
-
         <main class="py-4">
             @yield('content')
         </main>


### PR DESCRIPTION
# what
パンくずリストを商品詳細画面に追加。
今後カテゴリで検索が行えるようにした際には、
href属性に書き加え、検索画面でもパンくずリストを表示する。